### PR TITLE
GetSupplyRate Exhausted fix

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -447,6 +447,19 @@ contract Comet is CometMainInterface {
      * @return The per second supply rate at `utilization`
      */
     function getSupplyRate(uint utilization) override public view returns (uint64) {
+        if (totalSupplyBase == 0) return 0;
+
+        // In fresh markets with no borrows but positive base supply rate, lenders earn interest from reserves.
+        // If reserves are insufficient, total supply (with accrued interest) can exceed actual token balance,
+        // causing illiquidity. To prevent this, we cut off the supply rate when reserves are exhausted.
+        // Note: accrual happens BEFORE supply state change, so this check works only AFTER the last accrual.
+        // Total supply may slightly exceed balance, but this prevents infinite growth and limits the shortfall.
+        if (utilization == 0 && supplyPerSecondInterestRateBase != 0) {
+            if (presentValueSupply(baseSupplyIndex, totalSupplyBase) >= IERC20NonStandard(baseToken).balanceOf(address(this))) {
+                return 0;
+            }
+        }
+
         if (utilization <= supplyKink) {
             // interestRateBase + interestRateSlopeLow * utilization
             return safe64(supplyPerSecondInterestRateBase + mulFactor(supplyPerSecondInterestRateSlopeLow, utilization));

--- a/test/interest-rate-test.ts
+++ b/test/interest-rate-test.ts
@@ -116,4 +116,57 @@ describe('interest rates', function () {
     // = 0.01 + 0.05 * 0 = 0.01
     assertInterestRatesMatch(exp(0.01, 18), borrowRate.mul(SECONDS_PER_YEAR));
   });
+
+  it('returns 0 supply rate when reserves exhausted with no borrows', async () => {
+    const params = {
+      ...interestRateParams,
+      supplyInterestRateBase: exp(0.02, 18),
+    };
+    const { comet, tokens: { USDC } } = await makeProtocol(params);
+
+    const totals = {
+      trackingSupplyIndex: 0,
+      trackingBorrowIndex: 0,
+      baseSupplyIndex: exp(1.1, 15),
+      baseBorrowIndex: exp(1, 15),
+      totalSupplyBase: exp(1000, 6),
+      totalBorrowBase: 0,
+      lastAccrualTime: 0,
+      pauseFlags: 0,
+    };
+    await wait(comet.setTotalsBasic(totals));
+
+    const utilization = await comet.getUtilization();
+    expect(utilization).to.be.equal(0);
+
+    const balance = await USDC.balanceOf(comet.address);
+    const presentValue = totals.totalSupplyBase * BigInt(totals.baseSupplyIndex) / BigInt(exp(1, 15));
+    
+    if (presentValue >= balance.toBigInt()) {
+      const supplyRate = await comet.getSupplyRate(utilization);
+      expect(supplyRate).to.be.equal(0);
+    }
+  });
+
+  it('returns positive supply rate when reserves are sufficient with no borrows', async () => {
+    const params = {
+      ...interestRateParams,
+      supplyInterestRateBase: exp(0.02, 18),
+    };
+    const { comet, users: [alice], tokens: { USDC } } = await makeProtocol(params);
+    const supplyAmount = exp(100, 6);
+    await USDC.allocateTo(alice.address, supplyAmount);
+    await USDC.connect(alice).approve(comet.address, supplyAmount);
+    await wait(comet.connect(alice).supply(USDC.address, supplyAmount));
+
+    const reserveAmount = exp(50, 6);
+    await USDC.allocateTo(comet.address, reserveAmount);
+
+    const utilization = await comet.getUtilization();
+    expect(utilization).to.be.equal(0);
+
+    const supplyRate = await comet.getSupplyRate(utilization);
+    const baseRate = await comet.supplyPerSecondInterestRateBase();
+    expect(supplyRate).to.be.equal(baseRate);
+  });
 });


### PR DESCRIPTION
* when a market has no borrows (utilization = 0), positive base supply rate,
reserves exhausted (totalSupply ≥ token balance)
The `getSupplyRate` now returns 0 instead of the base rate.
* added test cases.