### PR TITLE
Asset price handling in `isLiquidatalbe + absorb` combination

### DIFF
--- a/contracts/CometWithExtendedAssetList.sol
+++ b/contracts/CometWithExtendedAssetList.sol
@@ -426,10 +426,10 @@ contract CometWithExtendedAssetList is CometMainInterface {
         uint256[] memory assetPrices
     ) {
         int104 principal = userBasic[account].principal;
-        assetPrices = new uint256[](numAssets);
 
         if (principal >= 0) return (false, basePrice, assetPrices);
-    
+
+        assetPrices = new uint256[](numAssets);
         uint16 assetsIn = userBasic[account].assetsIn;
         uint8 _reserved = userBasic[account]._reserved;
         basePrice = getPrice(baseTokenPriceFeed);

--- a/contracts/CometWithExtendedAssetList.sol
+++ b/contracts/CometWithExtendedAssetList.sol
@@ -416,41 +416,46 @@ contract CometWithExtendedAssetList is CometMainInterface {
      * @return Whether the account is minimally collateralized enough to not be liquidated
      */
     function isLiquidatable(address account) override public view returns (bool) {
+        (bool liquidatable, ,) = isLiquidatableInternal(account);
+        return liquidatable;
+    }
+
+    function isLiquidatableInternal(address account) internal view returns (
+        bool liquidatable,
+        uint256 basePrice,
+        uint256[] memory assetPrices
+    ) {
         int104 principal = userBasic[account].principal;
+        assetPrices = new uint256[](numAssets);
 
-        if (principal >= 0) {
-            return false;
-        }
-
+        if (principal >= 0) return (false, basePrice, assetPrices);
+    
         uint16 assetsIn = userBasic[account].assetsIn;
         uint8 _reserved = userBasic[account]._reserved;
+        basePrice = getPrice(baseTokenPriceFeed);
         int liquidity = signedMulPrice(
             presentValue(principal),
-            getPrice(baseTokenPriceFeed),
+            basePrice,
             uint64(baseScale)
         );
 
         for (uint8 i = 0; i < numAssets; ) {
             if (isInAsset(assetsIn, i, _reserved)) {
-                if (liquidity >= 0) {
-                    return false;
-                }
+                if (liquidity >= 0) return (false, basePrice, assetPrices);
 
                 AssetInfo memory asset = getAssetInfo(i);
+                assetPrices[i] = getPrice(asset.priceFeed);
                 uint newAmount = mulPrice(
                     userCollateral[account][asset.asset].balance,
-                    getPrice(asset.priceFeed),
+                    assetPrices[i],
                     asset.scale
                 );
-                liquidity += signed256(mulFactor(
-                    newAmount,
-                    asset.liquidateCollateralFactor
-                ));
+                liquidity += signed256(mulFactor(newAmount, asset.liquidateCollateralFactor));
             }
             unchecked { i++; }
         }
 
-        return liquidity < 0;
+        return (liquidity < 0, basePrice, assetPrices);
     }
 
     /**
@@ -1154,7 +1159,8 @@ contract CometWithExtendedAssetList is CometMainInterface {
      * @dev Transfer user's collateral and debt to the protocol itself.
      */
     function absorbInternal(address absorber, address account) internal {
-        if (!isLiquidatable(account)) revert NotLiquidatable();
+        (bool liquidatable, uint256 basePrice, uint256[] memory assetPrices) = isLiquidatableInternal(account);
+        if (!liquidatable) revert NotLiquidatable();
 
         UserBasic memory accountUser = userBasic[account];
         int104 oldPrincipal = accountUser.principal;
@@ -1162,7 +1168,6 @@ contract CometWithExtendedAssetList is CometMainInterface {
         uint16 assetsIn = accountUser.assetsIn;
         uint8 _reserved = accountUser._reserved;
 
-        uint256 basePrice = getPrice(baseTokenPriceFeed);
         uint256 deltaValue = 0;
 
         for (uint8 i = 0; i < numAssets; ) {
@@ -1173,7 +1178,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
                 userCollateral[account][asset].balance = 0;
                 totalsCollateral[asset].totalSupplyAsset -= seizeAmount;
 
-                uint256 value = mulPrice(seizeAmount, getPrice(assetInfo.priceFeed), assetInfo.scale);
+                uint256 value = mulPrice(seizeAmount, assetPrices[i], assetInfo.scale);
                 deltaValue += mulFactor(value, assetInfo.liquidationFactor);
 
                 emit AbsorbCollateral(absorber, account, asset, seizeAmount, value);


### PR DESCRIPTION
**Asset Price Handling in `isLiquidatable + absorb` Combination**

- **`isLiquidatable` logic refactored** - improved the internal logic of `isLiquidatable` in `CometWithExtendedAssetList` to better handle asset price fetching, likely addressing an issue where price fetching was done redundantly or incorrectly when `isLiquidatable` and `absorb` are called together.

- **Asset price handling optimization** - improved how asset prices are fetched and reused across the `isLiquidatable` + `absorbInternal` flow, reducing redundant price feed calls and ensuring price consistency between the liquidatability check and the actual absorption.

> This is a minimal, single-commit refactor targeting `feat/service-patch` directly, awaiting review from VladyslavBudiukWOOF.