### PR TITLE
Fix: Price fetching for deactivated collaterals, optimized factors validation in AssetList + new tests

### DIFF
--- a/contracts/AssetList.sol
+++ b/contracts/AssetList.sol
@@ -137,18 +137,17 @@ contract AssetList {
         if (IPriceFeed(priceFeed).decimals() != PRICE_FEED_DECIMALS) revert CometMainInterface.BadDecimals();
         if (IERC20NonStandard(asset).decimals() != decimals_) revert CometMainInterface.BadDecimals();
 
+        // Sanity checks for factors ordering: BCF < LCF; LCF <= MAX; LF <= MAX
+        if (assetConfig.borrowCollateralFactor >= assetConfig.liquidateCollateralFactor && assetConfig.borrowCollateralFactor != 0)
+            revert CometMainInterface.BorrowCFTooLarge();
+        if (assetConfig.liquidateCollateralFactor > MAX_COLLATERAL_FACTOR) revert CometMainInterface.LiquidateCFTooLarge();
+        if (assetConfig.liquidationFactor > MAX_COLLATERAL_FACTOR) revert CometMainInterface.LiqPenaltyTooHigh();
+
         // Valid collateral factor configurations:
-        //  1. Both zero => fully de-listed
+        //  1. Both BCF and LCF are 0 => collateral is fully de-listed
         //  2. borrowCF=0, liquidateCF>0 => soft de-list (no new borrows, controlled liquidation wind-down)
         //  3. Both non-zero, properly ordered => active collateral
         // Invalid: borrowCF>0, liquidateCF=0 => reverts (borrow power without liquidation coverage)
-        if (assetConfig.borrowCollateralFactor != 0 && assetConfig.liquidateCollateralFactor == 0) {
-            revert CometMainInterface.BorrowCFTooLarge();
-        } else if (assetConfig.borrowCollateralFactor != 0 && assetConfig.liquidateCollateralFactor != 0) {
-            // Ensure collateral factors are within range
-            if (assetConfig.borrowCollateralFactor > assetConfig.liquidateCollateralFactor) revert CometMainInterface.BorrowCFTooLarge();
-            if (assetConfig.liquidateCollateralFactor > MAX_COLLATERAL_FACTOR) revert CometMainInterface.LiquidateCFTooLarge();
-        }
 
         unchecked {
             // Keep 4 decimals for each factor
@@ -157,12 +156,8 @@ contract AssetList {
             uint16 liquidateCollateralFactor = uint16(assetConfig.liquidateCollateralFactor / descale);
             uint16 liquidationFactor = uint16(assetConfig.liquidationFactor / descale);
 
-            if (borrowCollateralFactor != 0 && liquidateCollateralFactor == 0) {
-                revert CometMainInterface.BorrowCFTooLarge();
-            } else if (borrowCollateralFactor != 0 && liquidateCollateralFactor != 0) {
-                // Be nice and check descaled values are still within range
-                if (borrowCollateralFactor >= liquidateCollateralFactor) revert CometMainInterface.BorrowCFTooLarge();
-            }
+            // safety check duplicate sanity check on original values to ensure no values skewing after descaling and type conversion
+            if (borrowCollateralFactor >= liquidateCollateralFactor && borrowCollateralFactor != 0) revert CometMainInterface.BorrowCFTooLarge();
 
             // Keep whole units of asset for supply cap
             uint64 supplyCap = uint64(assetConfig.supplyCap / (10 ** decimals_));

--- a/contracts/CometMainInterface.sol
+++ b/contracts/CometMainInterface.sol
@@ -20,6 +20,7 @@ abstract contract CometMainInterface is CometCore {
     error BorrowCFTooLarge();
     error InsufficientReserves();
     error LiquidateCFTooLarge();
+    error LiqPenaltyTooHigh();
     error NoSelfTransfer();
     error NotCollateralized();
     error NotForSale();

--- a/contracts/CometWithExtendedAssetList.sol
+++ b/contracts/CometWithExtendedAssetList.sol
@@ -435,7 +435,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
 
         AssetInfo memory asset;
         uint256 newAmount;
-        for (uint8 i; i < numAssets; ) {
+        for (uint8 i; i < numAssets; ++i) {
             if (isInAsset(assetsIn, i, _reserved)) {
                 if (liquidity >= 0) {
                     return true;
@@ -454,15 +454,11 @@ contract CometWithExtendedAssetList is CometMainInterface {
                 // under-collateralized, they are stuck and must wait for liquidation.
                 if (isCollateralDeactivated(asset.offset)) revert TokenIsDeactivated(asset.asset);
 
-                // Skip assets with borrowCollateralFactor == 0 — they provide no
-                // borrowing power, so mulFactor(value, 0) would add nothing to liquidity.
-                // More critically, this avoids calling getPrice() for their price feed:
-                // if a non-contributing asset's oracle reverts (stale, broken, decommissioned),
-                // it would otherwise block the entire collateralization check, paralyzing
-                // borrows and transfers for every account that holds that asset — even though
+                // Mechanism to skip assets with no borrowing power. It avoids getPrice() call price feed,
+                // so in case if excluded asset's oracle reverts (e.g. stale, broken, decommissioned),
+                // it won't block the entire collateralization check, and won't paralyze borrows and transfers.
                 // the asset has zero influence on their borrow capacity.
                 if (asset.borrowCollateralFactor == 0) { 
-                    unchecked { i++; } 
                     continue; 
                 }
 
@@ -476,7 +472,6 @@ contract CometWithExtendedAssetList is CometMainInterface {
                     asset.borrowCollateralFactor
                 ));
             }
-            unchecked { i++; }
         }
 
         return liquidity >= 0;
@@ -523,25 +518,20 @@ contract CometWithExtendedAssetList is CometMainInterface {
 
         AssetInfo memory asset;
         uint256 newAmount;
-        for (uint8 i; i < numAssets; ) {
+        for (uint8 i; i < numAssets; ++i) {
             if (isInAsset(assetsIn, i, _reserved)) {
                 if (liquidity >= 0) return (false, basePrice, assetPrices);
 
                 asset = getAssetInfo(i);
-                assetPrices[i] = getPrice(asset.priceFeed);
 
-                // Skip assets with liquidateCollateralFactor == 0 — they do not count
-                // toward the liquidation collateral threshold, so including them would
-                // add nothing to liquidity (mulFactor(value, 0) == 0).
-                // More critically, this avoids calling getPrice() for their price feed:
-                // if a non-contributing asset's oracle reverts (stale, broken, decommissioned),
-                // it would otherwise block the entire liquidation check, preventing
-                // liquidations for every account that holds that asset — even though
-                // the asset has zero influence on their liquidation status.
+                // Skip assets that do not count toward the liquidation threshold. It avoids getPrice() call for price feed
+                // so in case if excluded asset's oracle reverts (e.g. stale, broken, decommissioned),
+                // it won't block the entire liquidation check, and won't paralyze liquidations of accounts which hold it.
                 if (asset.liquidateCollateralFactor == 0) { 
-                    unchecked { i++; } 
                     continue; 
                 }
+
+                assetPrices[i] = getPrice(asset.priceFeed);
 
                 newAmount = mulPrice(
                     userCollateral[account][asset.asset].balance,
@@ -550,7 +540,6 @@ contract CometWithExtendedAssetList is CometMainInterface {
                 );
                 liquidity += signed256(mulFactor(newAmount, asset.liquidateCollateralFactor));
             }
-            unchecked { i++; }
         }
 
         return (liquidity < 0, basePrice, assetPrices);
@@ -1359,7 +1348,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
                 //    account, preventing liquidation even for assets that *should* be seized.
                 // 3. mulFactor(value, 0) would contribute nothing to deltaValue anyway.
                 if (assetInfo.liquidationFactor == 0) {
-                    unchecked { i++; }
+                    unchecked { ++i; }
                     continue;
                 }
 
@@ -1373,7 +1362,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
 
                 emit AbsorbCollateral(absorber, account, asset, seizeAmount, value);
             }
-            unchecked { i++; }
+            unchecked { ++i; }
         }
 
         uint256 deltaBalance = divPrice(deltaValue, basePrice, uint64(baseScale));

--- a/test/absorb-test.ts
+++ b/test/absorb-test.ts
@@ -835,7 +835,7 @@ describe('absorb', function () {
       snapshot = await takeSnapshot();
     });
 
-    describe('liquidation factor > 0', function () {
+    describe('LCF > 0 and LF > 0', function () {
       /*
        * This test suite verifies the standard absorption flow when liquidation factor > 0.
        *
@@ -929,7 +929,7 @@ describe('absorb', function () {
       });
     });
 
-    describe('liquidation factor = 0', function () {
+    describe('LCF > 0 and LF = 0', function () {
       /*
        * This test suite verifies the absorption flow when liquidation factor = 0.
        *
@@ -1022,6 +1022,273 @@ describe('absorb', function () {
         // Transfer event emits only when new principal is greater than 0
         expect(newPrincipal).to.equal(0);
         expect(liquidationTx).to.not.emit(comet, 'Transfer');
+      });
+    });
+
+    describe('LCF = 0 and LF > 0', function () {
+      /*
+       * Covers the case where governance zeros liquidateCF but leaves liquidationFactor > 0.
+       * The key invariant: isLiquidatableInternal skips price fetching for zero-LCF assets,
+       * so assetPrices[i] stays 0. When absorbInternal seizes the collateral (LF > 0), it uses
+       * that zero price — the collateral is physically moved to reserves but contributes no value
+       * to the debt offset, so the full borrow is absorbed by protocol reserves.
+       * AbsorbCollateral fires with usdValue = 0, distinguishing this from the normal seizure path.
+       */
+      let cometBaseTokenBalanceBefore: BigNumber;
+      let cometCompBalanceBefore: BigNumber;
+      let cometCompReservesBefore: BigNumber;
+      let computedDeltaBalance: bigint;
+      let computedNewBalance: bigint;
+      let computedRepayAmount: bigint;
+
+      before(async () => {
+        await snapshot.restore();
+        cometBaseTokenBalanceBefore = await baseToken.balanceOf(comet.address);
+        cometCompBalanceBefore = await compToken.balanceOf(comet.address);
+        cometCompReservesBefore = await comet.getCollateralReserves(compToken.address);
+      });
+
+      it('borrowCollateralFactor and liquidateCollateralFactor updated to 0', async () => {
+        await configurator.updateAssetBorrowCollateralFactor(cometProxyAddress, compToken.address, 0n);
+        await configurator.updateAssetLiquidateCollateralFactor(cometProxyAddress, compToken.address, 0n);
+        await proxyAdmin.deployAndUpgradeTo(configuratorProxy.address, cometProxyAddress);
+      });
+
+      it('liquidateCollateralFactor is 0 after upgrade', async () => {
+        expect((await comet.getAssetInfoByAddress(compToken.address)).liquidateCollateralFactor).to.equal(0);
+      });
+
+      it('liquidationFactor remains non-zero after upgrade', async () => {
+        expect((await comet.getAssetInfoByAddress(compToken.address)).liquidationFactor).to.be.gt(0);
+      });
+
+      it('alice is liquidatable with zero liquidateCollateralFactor', async () => {
+        expect(await comet.isLiquidatable(alice.address)).to.be.true;
+      });
+
+      it('absorbs undercollateralized account', async () => {
+        liquidationTx = await comet.connect(bob).absorb(bob.address, [alice.address]);
+        expect(liquidationTx).to.not.be.reverted;
+      });
+
+      it('emits AbsorbCollateral event with usdValue of 0', async () => {
+        // assetPrices[i] stays 0 because isLiquidatableInternal skips LCF=0 assets before calling getPrice()
+        // value = mulPrice(seizeAmount, 0, scale) = 0
+        expect(liquidationTx).to.emit(comet, 'AbsorbCollateral').withArgs(bob.address, alice.address, compToken.address, aliceCompSupply, 0n);
+      });
+
+      it('reduces totals supply of the asset for seized asset', async () => {
+        const totals = await comet.totalsCollateral(compToken.address);
+        expect(totals.totalSupplyAsset).to.equal(0);
+      });
+
+      it('sets user collateral balance to 0', async () => {
+        expect((await comet.userCollateral(alice.address, compToken.address)).balance).to.equal(0);
+      });
+
+      it('resets user assetsIn to 0', async () => {
+        expect((await comet.userBasic(alice.address)).assetsIn).to.equal(0);
+        expect((await comet.userBasic(alice.address))._reserved).to.equal(0);
+      });
+
+      it('deltaBalance is 0 when deltaValue is 0', () => {
+        // assetPrices[i] = 0 for LCF = 0 assets → deltaValue = 0 → deltaBalance = divPrice(0, price, scale) = 0
+        computedDeltaBalance = divPrice(0n, basePrice, baseScale);
+        expect(computedDeltaBalance).to.equal(0n);
+      });
+
+      it('new balance is clamped to 0 from the negative old borrow balance', () => {
+        // oldBalance < 0, deltaBalance = 0 → unclamped = oldBalance (still negative) → clamped to 0
+        const unclamped = oldBalance + computedDeltaBalance;
+        expect(unclamped < 0).to.be.true;
+        computedNewBalance = 0n;
+      });
+
+      it('new principal is 0 and matches stored principal', async () => {
+        const totalsBasic = await cometExt.totalsBasic();
+        newPrincipal = principalValue(computedNewBalance, totalsBasic.baseSupplyIndex, totalsBasic.baseBorrowIndex);
+        expect(newPrincipal).to.equal(0n);
+        expect((await comet.userBasic(alice.address)).principal).to.equal(0n);
+      });
+
+      it('repay amount equals the absorbed borrow', () => {
+        // repayAmount = newPrincipal - oldPrincipal = 0 - oldPrincipal = -oldPrincipal > 0
+        computedRepayAmount = newPrincipal - oldPrincipal;
+        expect(computedRepayAmount > 0n).to.be.true;
+      });
+
+      it('supply amount is 0 since new principal does not exceed 0', () => {
+        // supplyAmount = 0 when newPrincipal <= 0 (see repayAndSupplyAmount)
+        expect(newPrincipal <= 0n).to.be.true;
+      });
+
+      it('totalSupplyBase is unchanged after absorption', async () => {
+        const current = await cometExt.totalsBasic();
+        expect(current.totalSupplyBase).to.equal(totalSupplyBase);
+      });
+
+      it('totalBorrowBase is reduced by repay amount after absorption', async () => {
+        const current = await cometExt.totalsBasic();
+        expect(current.totalBorrowBase).to.equal(totalBorrowBase.toBigInt() - computedRepayAmount);
+      });
+
+      it('emits AbsorbDebt event', async () => {
+        // basePaidOut = computedNewBalance - oldBalance = 0 - oldBalance = -oldBalance (full debt absorbed by reserves)
+        const basePaidOut = computedNewBalance - oldBalance;
+        const valueOfBasePaidOut = mulPrice(basePaidOut, basePrice, baseScale);
+        expect(liquidationTx).to.emit(comet, 'AbsorbDebt').withArgs(bob.address, alice.address, basePaidOut, valueOfBasePaidOut);
+      });
+
+      it('Transfer event is not emitted', async () => {
+        expect(liquidationTx).to.not.emit(comet, 'Transfer');
+      });
+
+      it('comet base token ERC20 balance is unchanged after absorption', async () => {
+        // absorb does not transfer base tokens; debt absorption is an accounting change only
+        expect(await baseToken.balanceOf(comet.address)).to.equal(cometBaseTokenBalanceBefore);
+      });
+
+      it('comet collateral token ERC20 balance is unchanged after absorption', async () => {
+        // seized tokens remain locked in the comet contract; they are reclassified to reserves, not transferred out
+        expect(await compToken.balanceOf(comet.address)).to.equal(cometCompBalanceBefore);
+      });
+
+      it('comet collateral reserves increase by the seized amount', async () => {
+        // getCollateralReserves = balanceOf(comet) - totalsCollateral.totalSupplyAsset
+        // after seizure: totalSupplyAsset = 0, balanceOf unchanged → reserves grow by aliceCompSupply
+        expect(await comet.getCollateralReserves(compToken.address)).to.equal(cometCompReservesBefore.add(aliceCompSupply));
+      });
+    });
+
+    describe('LCF = 0 and LF = 0', function () {
+      /*
+       * Full de-listing: both liquidateCF and liquidationFactor are zero. The account is
+       * liquidatable (LCF = 0 removes all collateral coverage), but absorption skips the
+       * collateral entirely (LF = 0). The borrow is absorbed by reserves, the collateral
+       * balance remains in the user's protocol account, and assetsIn is reset to 0 — leaving
+       * the collateral stranded until governance decides how to handle it.
+       */
+      let cometBaseTokenBalanceBefore: BigNumber;
+      let cometCompBalanceBefore: BigNumber;
+      let cometCompReservesBefore: BigNumber;
+      let computedDeltaBalance: bigint;
+      let computedNewBalance: bigint;
+      let computedRepayAmount: bigint;
+
+      before(async () => {
+        await snapshot.restore();
+        cometBaseTokenBalanceBefore = await baseToken.balanceOf(comet.address);
+        cometCompBalanceBefore = await compToken.balanceOf(comet.address);
+        cometCompReservesBefore = await comet.getCollateralReserves(compToken.address);
+      });
+
+      it('borrowCollateralFactor, liquidateCollateralFactor and liquidationFactor can be updated to 0', async () => {
+        await configurator.updateAssetBorrowCollateralFactor(cometProxyAddress, compToken.address, 0n);
+        await configurator.updateAssetLiquidateCollateralFactor(cometProxyAddress, compToken.address, 0n);
+        await configurator.updateAssetLiquidationFactor(cometProxyAddress, compToken.address, 0n);
+        await proxyAdmin.deployAndUpgradeTo(configuratorProxy.address, cometProxyAddress);
+      });
+
+      it('liquidateCollateralFactor is 0 after upgrade', async () => {
+        expect((await comet.getAssetInfoByAddress(compToken.address)).liquidateCollateralFactor).to.equal(0);
+      });
+
+      it('liquidationFactor is 0 after upgrade', async () => {
+        expect((await comet.getAssetInfoByAddress(compToken.address)).liquidationFactor).to.equal(0);
+      });
+
+      it('alice is liquidatable with zero liquidateCollateralFactor and zero liquidationFactor', async () => {
+        expect(await comet.isLiquidatable(alice.address)).to.be.true;
+      });
+
+      it('absorbs is successful', async () => {
+        liquidationTx = await comet.connect(bob).absorb(bob.address, [alice.address]);
+        expect(liquidationTx).to.not.be.reverted;
+      });
+
+      it('does not emit AbsorbCollateral event', async () => {
+        expect(liquidationTx).to.not.emit(comet, 'AbsorbCollateral');
+      });
+
+      it('does not affect user collateral balance', async () => {
+        expect((await comet.userCollateral(alice.address, compToken.address)).balance).to.equal(userCollateralBeforeAbsorption);
+      });
+
+      it('does not affect totals supply of the asset', async () => {
+        expect((await comet.totalsCollateral(compToken.address)).totalSupplyAsset).to.equal(totalsSupplyAssetBeforeAbsorption);
+      });
+
+      it('resets user assetsIn to 0 even though collateral was not seized', async () => {
+        // absorbInternal always resets assetsIn regardless of liquidationFactor
+        expect((await comet.userBasic(alice.address)).assetsIn).to.equal(0);
+        expect((await comet.userBasic(alice.address))._reserved).to.equal(0);
+      });
+
+      it('deltaBalance is 0 when deltaValue is 0', () => {
+        // asset skipped in absorbInternal (LF = 0) → deltaValue = 0 → deltaBalance = divPrice(0, price, scale) = 0
+        computedDeltaBalance = divPrice(0n, basePrice, baseScale);
+        expect(computedDeltaBalance).to.equal(0n);
+      });
+
+      it('new balance is clamped to 0 from the negative old borrow balance', () => {
+        // oldBalance < 0, deltaBalance = 0 → unclamped = oldBalance (still negative) → clamped to 0
+        const unclamped = oldBalance + computedDeltaBalance;
+        expect(unclamped < 0).to.be.true;
+        computedNewBalance = 0n;
+      });
+
+      it('new principal is 0 and matches stored principal', async () => {
+        const totalsBasic = await cometExt.totalsBasic();
+        newPrincipal = principalValue(computedNewBalance, totalsBasic.baseSupplyIndex, totalsBasic.baseBorrowIndex);
+        expect(newPrincipal).to.equal(0n);
+        expect((await comet.userBasic(alice.address)).principal).to.equal(0n);
+      });
+
+      it('repay amount equals the absorbed borrow', () => {
+        // repayAmount = newPrincipal - oldPrincipal = 0 - oldPrincipal = -oldPrincipal > 0
+        computedRepayAmount = newPrincipal - oldPrincipal;
+        expect(computedRepayAmount > 0n).to.be.true;
+      });
+
+      it('supply amount is 0 since new principal does not exceed 0', () => {
+        // supplyAmount = 0 when newPrincipal <= 0 (see repayAndSupplyAmount)
+        expect(newPrincipal <= 0n).to.be.true;
+      });
+
+      it('totalSupplyBase is unchanged after absorption', async () => {
+        const current = await cometExt.totalsBasic();
+        expect(current.totalSupplyBase).to.equal(totalSupplyBase);
+      });
+
+      it('totalBorrowBase is reduced by repay amount after absorption', async () => {
+        const current = await cometExt.totalsBasic();
+        expect(current.totalBorrowBase).to.equal(totalBorrowBase.toBigInt() - computedRepayAmount);
+      });
+
+      it('emits AbsorbDebt event', async () => {
+        // basePaidOut = computedNewBalance - oldBalance = 0 - oldBalance = -oldBalance (full debt absorbed by reserves)
+        const basePaidOut = computedNewBalance - oldBalance;
+        const valueOfBasePaidOut = mulPrice(basePaidOut, basePrice, baseScale);
+        expect(liquidationTx).to.emit(comet, 'AbsorbDebt').withArgs(bob.address, alice.address, basePaidOut, valueOfBasePaidOut);
+      });
+
+      it('Transfer event is not emitted', async () => {
+        expect(liquidationTx).to.not.emit(comet, 'Transfer');
+      });
+
+      it('comet base token ERC20 balance is unchanged after absorption', async () => {
+        // absorb does not transfer base tokens; debt absorption is an accounting change only
+        expect(await baseToken.balanceOf(comet.address)).to.equal(cometBaseTokenBalanceBefore);
+      });
+
+      it('comet collateral token ERC20 balance is unchanged after absorption', async () => {
+        // collateral was not seized; tokens remain in the protocol account, still locked in comet
+        expect(await compToken.balanceOf(comet.address)).to.equal(cometCompBalanceBefore);
+      });
+
+      it('comet collateral reserves are unchanged after absorption', async () => {
+        // no seizure occurred; getCollateralReserves = balanceOf(comet) - totalSupplyAsset remains the same
+        expect(await comet.getCollateralReserves(compToken.address)).to.equal(cometCompReservesBefore);
       });
     });
 

--- a/test/absorb-test.ts
+++ b/test/absorb-test.ts
@@ -835,7 +835,7 @@ describe('absorb', function () {
       snapshot = await takeSnapshot();
     });
 
-    describe('LCF > 0 and LF > 0', function () {
+    describe('asset can be liquidated with positive liquidation collateral factor and liquidation factor', function () {
       /*
        * This test suite verifies the standard absorption flow when liquidation factor > 0.
        *
@@ -929,7 +929,7 @@ describe('absorb', function () {
       });
     });
 
-    describe('LCF > 0 and LF = 0', function () {
+    describe('skips liquidation for asset with liquidationF = 0', function () {
       /*
        * This test suite verifies the absorption flow when liquidation factor = 0.
        *
@@ -1025,7 +1025,7 @@ describe('absorb', function () {
       });
     });
 
-    describe('LCF = 0 and LF > 0', function () {
+    describe('asset abosorbs with zero value when liquidateCF > 0 and liquidationF is positive', function () {
       /*
        * Covers the case where governance zeros liquidateCF but leaves liquidationFactor > 0.
        * The key invariant: isLiquidatableInternal skips price fetching for zero-LCF assets,
@@ -1160,7 +1160,7 @@ describe('absorb', function () {
       });
     });
 
-    describe('LCF = 0 and LF = 0', function () {
+    describe('asset ignored during absorption when liquidateCF = 0 and liquidationF = 0', function () {
       /*
        * Full de-listing: both liquidateCF and liquidationFactor are zero. The account is
        * liquidatable (LCF = 0 removes all collateral coverage), but absorption skips the

--- a/test/asset-info-test-asset-list-comet.ts
+++ b/test/asset-info-test-asset-list-comet.ts
@@ -1,4 +1,5 @@
-import { expect, exp, makeConfigurator, ONE, makeProtocol } from './helpers';
+import { AssetList, AssetList__factory, AssetListFactory, AssetListFactory__factory, FaucetToken, FaucetToken__factory, SimplePriceFeed, SimplePriceFeed__factory } from 'build/types';
+import { expect, exp, makeConfigurator, ONE, makeProtocol, ethers } from './helpers';
 
 describe('asset info', function () {
   it('initializes protocol', async () => {
@@ -72,30 +73,228 @@ describe('asset info', function () {
     await expect(cometWithExtendedAssetList.getAssetInfo(3)).to.be.revertedWith("custom error 'BadAsset()'");
   });
 
-  it('reverts if collateral factors are out of range', async () => {
-    await expect(makeConfigurator({
-      assets: {
-        USDC: {},
-        ASSET1: {borrowCF: exp(0.9, 18), liquidateCF: exp(0.9, 18)},
-        ASSET2: {},
-      },
-    })).to.be.revertedWith("custom error 'BorrowCFTooLarge()'");
+  describe('factors validation', function () {
+    // FACTOR_SCALE / 1e4 — the precision unit factors are truncated to when packed into AssetList storage
+    const DESCALE = exp(1, 14);
 
-    // check descaled factors
-    await expect(makeConfigurator({
-      assets: {
-        USDC: {},
-        ASSET1: {borrowCF: exp(0.9, 18), liquidateCF: exp(0.9, 18) + 1n},
-        ASSET2: {},
-      },
-    })).to.be.revertedWith("custom error 'BorrowCFTooLarge()'");
+    let assetList: AssetList;
+    let assetListFactory: AssetListFactory;
+    let faucetToken: FaucetToken;
+    let priceFeed: SimplePriceFeed;
 
-    await expect(makeConfigurator({
-      assets: {
-        USDC: {},
-        ASSET1: {borrowCF: exp(0.99, 18), liquidateCF: exp(1.1, 18)},
-        ASSET2: {},
-      },
-    })).to.be.revertedWith("custom error 'LiquidateCFTooLarge()'");
+    // Base valid config; each test spreads this and overrides only the field(s) under test.
+    let baseAssetConfig: {
+      asset: string;
+      priceFeed: string;
+      decimals: number;
+      borrowCollateralFactor: bigint;
+      liquidateCollateralFactor: bigint;
+      liquidationFactor: bigint;
+      supplyCap: bigint;
+    };
+
+    before(async () => {
+      assetListFactory = await (await ethers.getContractFactory('AssetListFactory') as AssetListFactory__factory).deploy();
+      await assetListFactory.deployed();
+
+      faucetToken = await (await ethers.getContractFactory('FaucetToken') as FaucetToken__factory).deploy(10n ** 24n, 'Test Token', 18, 'TEST');
+      await faucetToken.deployed();
+
+      priceFeed = await (await ethers.getContractFactory('SimplePriceFeed') as SimplePriceFeed__factory).deploy(exp(1, 8), 8);
+      await priceFeed.deployed();
+
+      baseAssetConfig = {
+        asset: faucetToken.address,
+        priceFeed: priceFeed.address,
+        decimals: 18,
+        borrowCollateralFactor: exp(0.75, 18),
+        liquidateCollateralFactor: exp(0.8, 18),
+        liquidationFactor: exp(0.9, 18),
+        supplyCap: 10n ** 24n,
+      };
+
+      assetList = await (await ethers.getContractFactory('AssetList') as AssetList__factory).deploy([baseAssetConfig]);
+      await assetList.deployed();
+    });
+
+    describe('happy cases', function () {
+      it('borrowCF > 0, liquidateCF > 0 and borrowCF < liquidateCF', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig }])).to.not.be.reverted;
+      });
+
+      it('borrowCF = 0, liquidateCF = 0', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: 0n }])).to.not.be.reverted;
+      });
+
+      it('borrowCF > liquidateF and borrowCF < liquidateCF', async () => {
+        await expect(assetListFactory.createAssetList([{
+          ...baseAssetConfig,
+          borrowCollateralFactor: exp(0.95, 18),
+          liquidateCollateralFactor: exp(0.98, 18),
+          liquidationFactor: exp(0.9, 18),
+        }])).to.not.be.reverted;
+      });
+
+      it('borrowCF < liquidateCF and liquidateCF > liquidateF', async () => {
+        await expect(assetListFactory.createAssetList([{
+          ...baseAssetConfig,
+          borrowCollateralFactor: exp(0.7, 18),
+          liquidateCollateralFactor: exp(0.95, 18),
+          liquidationFactor: exp(0.9, 18),
+        }])).to.not.be.reverted;
+      });
+
+      it('borrowCF < liquidateCF < liquidateF', async () => {
+        await expect(assetListFactory.createAssetList([{
+          ...baseAssetConfig,
+          borrowCollateralFactor: exp(0.7, 18),
+          liquidateCollateralFactor: exp(0.8, 18),
+          liquidationFactor: exp(0.95, 18),
+        }])).to.not.be.reverted;
+      });
+
+      it('borrowCF = 0 and liquidateCF > 0', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n }])).to.not.be.reverted;
+      });
+
+      it('borrowCF = 0, liquidateF = 0, liquidateCF > 0', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidationFactor: 0n }])).to.not.be.reverted;
+      });
+
+      it('liquidateCF < MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: ONE - DESCALE }])).to.not.be.reverted;
+      });
+
+      it('liquidateCF = MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: ONE }])).to.not.be.reverted;
+      });
+
+      it('liquidateF < MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE - DESCALE }])).to.not.be.reverted;
+      });
+
+      it('liquidateF = MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE }])).to.not.be.reverted;
+      });
+    });
+
+    describe('revert when', function () {
+      it('borrowCF > 0, liquidateCF = 0', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: 0n }]))
+          .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+      });
+
+      it('borrowCF > 0, liquidateCF > 0 and borrowCF > liquidateCF', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: exp(0.9, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
+          .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+      });
+
+      it('borrowCF > 0, liquidateCF > 0 and borrowCF = liquidateCF', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: exp(0.8, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
+          .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+      });
+
+      it('liquidateCF > MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: ONE + 1n }]))
+          .to.be.revertedWithCustomError(assetList, 'LiquidateCFTooLarge');
+      });
+
+      it('liquidateF > MAX_COLLATERAL_FACTOR', async () => {
+        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE + 1n }]))
+          .to.be.revertedWithCustomError(assetList, 'LiqPenaltyTooHigh');
+      });
+    });
+
+    /*
+     * Factors are truncated to 4-decimal precision (DESCALE = 1e14) when packed into AssetList
+     * storage. A post-descale safety check re-runs the BorrowCFTooLarge guard on packed values,
+     * catching cases where original values pass the first check but collapse into the same bin.
+     */
+    describe('descaled values', function () {
+      describe('happy cases', function () {
+        it('both factors are exact multiples of DESCALE with a clear gap', async () => {
+          // 0.9e18 → 9000 units, 0.91e18 → 9100 units after descale
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18),
+            liquidateCollateralFactor: exp(0.91, 18),
+          }])).to.not.be.reverted;
+        });
+
+        it('gap is exactly one DESCALE unit — minimum valid separation', async () => {
+          // 9000*DESCALE → 9001*DESCALE: packed values differ by 1 unit
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18),
+            liquidateCollateralFactor: exp(0.9, 18) + DESCALE,
+          }])).to.not.be.reverted;
+        });
+
+        it('borrowCF just below a bin boundary, liquidateCF at that boundary', async () => {
+          // borrowCF = 9000*DESCALE - 1 → truncates to bin 8999; liquidateCF = 9000*DESCALE → bin 9000
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18) - 1n,
+            liquidateCollateralFactor: exp(0.9, 18),
+          }])).to.not.be.reverted;
+        });
+
+        it('borrowCF inside a bin, liquidateCF at the start of the next bin', async () => {
+          // borrowCF = 9000*DESCALE + 1 → bin 9000; liquidateCF = 9001*DESCALE → bin 9001
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18) + 1n,
+            liquidateCollateralFactor: exp(0.9, 18) + DESCALE,
+          }])).to.not.be.reverted;
+        });
+
+        it('borrowCF = 0 with liquidateCF below DESCALE — descale check is skipped', async () => {
+          // Packed borrowCollateralFactor = 0 → the != 0 guard short-circuits the descale check
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: 0n,
+            liquidateCollateralFactor: 1n,
+          }])).to.not.be.reverted;
+        });
+      });
+
+      describe('revert when', function () {
+        it('gap = 1: liquidateCF is in the same bin as borrowCF after truncation', async () => {
+          // 9000*DESCALE and 9000*DESCALE + 1 both truncate to 9000 → equal after descale
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18),
+            liquidateCollateralFactor: exp(0.9, 18) + 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
+
+        it('gap = DESCALE - 1: maximum same-bin gap — liquidateCF still truncates to the same bin', async () => {
+          // 9001*DESCALE - 1 truncates to 9000, same as 9000*DESCALE
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18),
+            liquidateCollateralFactor: exp(0.9, 18) + DESCALE - 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
+
+        it('both values are non-zero and inside the same bin', async () => {
+          // borrowCF = 9000*DESCALE + 1, liquidateCF = 9001*DESCALE - 1 → both truncate to 9000
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.9, 18) + 1n,
+            liquidateCollateralFactor: exp(0.9, 18) + DESCALE - 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
+
+        it('same-bin collision at a different factor magnitude', async () => {
+          // 7000*DESCALE and 7000*DESCALE + 1 both truncate to 7000 → equal after descale
+          await expect(assetListFactory.createAssetList([{
+            ...baseAssetConfig,
+            borrowCollateralFactor: exp(0.7, 18),
+            liquidateCollateralFactor: exp(0.7, 18) + 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
+      });
+    });
   });
 });

--- a/test/asset-info-test-asset-list-comet.ts
+++ b/test/asset-info-test-asset-list-comet.ts
@@ -1,5 +1,6 @@
 import { AssetList, AssetList__factory, AssetListFactory, AssetListFactory__factory, FaucetToken, FaucetToken__factory, SimplePriceFeed, SimplePriceFeed__factory } from 'build/types';
 import { expect, exp, makeConfigurator, ONE, makeProtocol, ethers } from './helpers';
+import { AssetInfoStructOutput } from 'build/types/AssetList';
 
 describe('asset info', function () {
   it('initializes protocol', async () => {
@@ -83,7 +84,7 @@ describe('asset info', function () {
     let priceFeed: SimplePriceFeed;
 
     // Base valid config; each test spreads this and overrides only the field(s) under test.
-    let baseAssetConfig: {
+    let collateralAssetConfig: {
       asset: string;
       priceFeed: string;
       decimals: number;
@@ -103,7 +104,7 @@ describe('asset info', function () {
       priceFeed = await (await ethers.getContractFactory('SimplePriceFeed') as SimplePriceFeed__factory).deploy(exp(1, 8), 8);
       await priceFeed.deployed();
 
-      baseAssetConfig = {
+      collateralAssetConfig = {
         asset: faucetToken.address,
         priceFeed: priceFeed.address,
         decimals: 18,
@@ -113,22 +114,22 @@ describe('asset info', function () {
         supplyCap: 10n ** 24n,
       };
 
-      assetList = await (await ethers.getContractFactory('AssetList') as AssetList__factory).deploy([baseAssetConfig]);
+      assetList = await (await ethers.getContractFactory('AssetList') as AssetList__factory).deploy([collateralAssetConfig]);
       await assetList.deployed();
     });
 
     describe('happy cases', function () {
       it('borrowCF > 0, liquidateCF > 0 and borrowCF < liquidateCF', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig }])).to.not.be.reverted;
       });
 
       it('borrowCF = 0, liquidateCF = 0', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: 0n }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: 0n }])).to.not.be.reverted;
       });
 
       it('borrowCF > liquidateF and borrowCF < liquidateCF', async () => {
         await expect(assetListFactory.createAssetList([{
-          ...baseAssetConfig,
+          ...collateralAssetConfig,
           borrowCollateralFactor: exp(0.95, 18),
           liquidateCollateralFactor: exp(0.98, 18),
           liquidationFactor: exp(0.9, 18),
@@ -137,7 +138,7 @@ describe('asset info', function () {
 
       it('borrowCF < liquidateCF and liquidateCF > liquidateF', async () => {
         await expect(assetListFactory.createAssetList([{
-          ...baseAssetConfig,
+          ...collateralAssetConfig,
           borrowCollateralFactor: exp(0.7, 18),
           liquidateCollateralFactor: exp(0.95, 18),
           liquidationFactor: exp(0.9, 18),
@@ -146,7 +147,7 @@ describe('asset info', function () {
 
       it('borrowCF < liquidateCF < liquidateF', async () => {
         await expect(assetListFactory.createAssetList([{
-          ...baseAssetConfig,
+          ...collateralAssetConfig,
           borrowCollateralFactor: exp(0.7, 18),
           liquidateCollateralFactor: exp(0.8, 18),
           liquidationFactor: exp(0.95, 18),
@@ -154,54 +155,156 @@ describe('asset info', function () {
       });
 
       it('borrowCF = 0 and liquidateCF > 0', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: 0n }])).to.not.be.reverted;
       });
 
       it('borrowCF = 0, liquidateF = 0, liquidateCF > 0', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidationFactor: 0n }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: 0n, liquidationFactor: 0n }])).to.not.be.reverted;
       });
 
       it('liquidateCF < MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: ONE - DESCALE }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidateCollateralFactor: ONE - DESCALE }])).to.not.be.reverted;
       });
 
       it('liquidateCF = MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: ONE }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidateCollateralFactor: ONE }])).to.not.be.reverted;
       });
 
       it('liquidateF < MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE - DESCALE }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidationFactor: ONE - DESCALE }])).to.not.be.reverted;
       });
 
       it('liquidateF = MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE }])).to.not.be.reverted;
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidationFactor: ONE }])).to.not.be.reverted;
       });
     });
 
     describe('revert when', function () {
       it('borrowCF > 0, liquidateCF = 0', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidateCollateralFactor: 0n }]))
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidateCollateralFactor: 0n }]))
           .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
       });
 
       it('borrowCF > 0, liquidateCF > 0 and borrowCF > liquidateCF', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: exp(0.9, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: exp(0.9, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
           .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
       });
 
       it('borrowCF > 0, liquidateCF > 0 and borrowCF = liquidateCF', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: exp(0.8, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: exp(0.8, 18), liquidateCollateralFactor: exp(0.8, 18) }]))
           .to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
       });
 
       it('liquidateCF > MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: ONE + 1n }]))
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, borrowCollateralFactor: 0n, liquidateCollateralFactor: ONE + 1n }]))
           .to.be.revertedWithCustomError(assetList, 'LiquidateCFTooLarge');
       });
 
       it('liquidateF > MAX_COLLATERAL_FACTOR', async () => {
-        await expect(assetListFactory.createAssetList([{ ...baseAssetConfig, liquidationFactor: ONE + 1n }]))
+        await expect(assetListFactory.createAssetList([{ ...collateralAssetConfig, liquidationFactor: ONE + 1n }]))
           .to.be.revertedWithCustomError(assetList, 'LiqPenaltyTooHigh');
+      });
+    });
+
+    /*
+     * When every factor is a positive integer smaller than DESCALE (1e14), truncation zeroes them
+     * all out after packing. The post-descale BorrowCFTooLarge guard is conditioned on
+     * packedBorrowCF != 0, so it short-circuits. Only the raw pre-descale checks apply.
+     * State is verified by attaching to the address returned via callStatic.
+     */
+    describe('all factors > 0 and below DESCALE — pack to zero', function () {
+      describe('happy cases', function () {
+        describe('minimum valid values: borrowCF = 1, liquidateCF = 2, liquidationFactor = 1', function () {
+          let assetInfo: AssetInfoStructOutput;
+
+          before(async () => {
+            const config = [{ ...collateralAssetConfig, borrowCollateralFactor: 1n, liquidateCollateralFactor: 2n, liquidationFactor: 1n }];
+            const address = await assetListFactory.callStatic.createAssetList(config);
+            await assetListFactory.createAssetList(config);
+            const deployedAssetList = await ethers.getContractAt('AssetList', address);
+            assetInfo = await deployedAssetList.getAssetInfo(0);
+          });
+
+          it('borrowCollateralFactor packs to zero', async () => {
+            expect(assetInfo.borrowCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidateCollateralFactor packs to zero', async () => {
+            expect(assetInfo.liquidateCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidationFactor packs to zero', async () => {
+            expect(assetInfo.liquidationFactor).to.equal(0n);
+          });
+        });
+
+        describe('maximum sub-DESCALE values: borrowCF = 1, liquidateCF and liquidationFactor at DESCALE - 1', function () {
+          let assetInfo: AssetInfoStructOutput;
+
+          before(async () => {
+            const config = [{ ...collateralAssetConfig, borrowCollateralFactor: 1n, liquidateCollateralFactor: DESCALE - 1n, liquidationFactor: DESCALE - 1n }];
+            const address = await assetListFactory.callStatic.createAssetList(config);
+            await assetListFactory.createAssetList(config);
+            const deployedAssetList = await ethers.getContractAt('AssetList', address);
+            assetInfo = await deployedAssetList.getAssetInfo(0);
+          });
+
+          it('borrowCollateralFactor packs to zero', async () => {
+            expect(assetInfo.borrowCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidateCollateralFactor packs to zero', async () => {
+            expect(assetInfo.liquidateCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidationFactor packs to zero', async () => {
+            expect(assetInfo.liquidationFactor).to.equal(0n);
+          });
+        });
+
+        describe('borrowCF just below liquidateCF: both at adjacent sub-DESCALE positions', function () {
+          let assetInfo: AssetInfoStructOutput;
+
+          before(async () => {
+            const config = [{ ...collateralAssetConfig, borrowCollateralFactor: DESCALE - 2n, liquidateCollateralFactor: DESCALE - 1n, liquidationFactor: 1n }];
+            const address = await assetListFactory.callStatic.createAssetList(config);
+            await assetListFactory.createAssetList(config);
+            const deployedAssetList = await ethers.getContractAt('AssetList', address);
+            assetInfo = await deployedAssetList.getAssetInfo(0);
+          });
+
+          it('borrowCollateralFactor packs to zero', async () => {
+            expect(assetInfo.borrowCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidateCollateralFactor packs to zero', async () => {
+            expect(assetInfo.liquidateCollateralFactor).to.equal(0n);
+          });
+
+          it('liquidationFactor packs to zero', async () => {
+            expect(assetInfo.liquidationFactor).to.equal(0n);
+          });
+        });
+      });
+
+      describe('revert when', function () {
+        it('borrowCF > liquidateCF: pre-descale ordering check fires even though both pack to zero', async () => {
+          await expect(assetListFactory.createAssetList([{
+            ...collateralAssetConfig,
+            borrowCollateralFactor: 2n,
+            liquidateCollateralFactor: 1n,
+            liquidationFactor: 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
+
+        it('borrowCF = liquidateCF: pre-descale equality check fires even though both pack to zero', async () => {
+          await expect(assetListFactory.createAssetList([{
+            ...collateralAssetConfig,
+            borrowCollateralFactor: 1n,
+            liquidateCollateralFactor: 1n,
+            liquidationFactor: 1n,
+          }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
+        });
       });
     });
 
@@ -215,7 +318,7 @@ describe('asset info', function () {
         it('both factors are exact multiples of DESCALE with a clear gap', async () => {
           // 0.9e18 → 9000 units, 0.91e18 → 9100 units after descale
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18),
             liquidateCollateralFactor: exp(0.91, 18),
           }])).to.not.be.reverted;
@@ -224,7 +327,7 @@ describe('asset info', function () {
         it('gap is exactly one DESCALE unit — minimum valid separation', async () => {
           // 9000*DESCALE → 9001*DESCALE: packed values differ by 1 unit
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18),
             liquidateCollateralFactor: exp(0.9, 18) + DESCALE,
           }])).to.not.be.reverted;
@@ -233,7 +336,7 @@ describe('asset info', function () {
         it('borrowCF just below a bin boundary, liquidateCF at that boundary', async () => {
           // borrowCF = 9000*DESCALE - 1 → truncates to bin 8999; liquidateCF = 9000*DESCALE → bin 9000
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18) - 1n,
             liquidateCollateralFactor: exp(0.9, 18),
           }])).to.not.be.reverted;
@@ -242,7 +345,7 @@ describe('asset info', function () {
         it('borrowCF inside a bin, liquidateCF at the start of the next bin', async () => {
           // borrowCF = 9000*DESCALE + 1 → bin 9000; liquidateCF = 9001*DESCALE → bin 9001
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18) + 1n,
             liquidateCollateralFactor: exp(0.9, 18) + DESCALE,
           }])).to.not.be.reverted;
@@ -251,7 +354,7 @@ describe('asset info', function () {
         it('borrowCF = 0 with liquidateCF below DESCALE — descale check is skipped', async () => {
           // Packed borrowCollateralFactor = 0 → the != 0 guard short-circuits the descale check
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: 0n,
             liquidateCollateralFactor: 1n,
           }])).to.not.be.reverted;
@@ -262,7 +365,7 @@ describe('asset info', function () {
         it('gap = 1: liquidateCF is in the same bin as borrowCF after truncation', async () => {
           // 9000*DESCALE and 9000*DESCALE + 1 both truncate to 9000 → equal after descale
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18),
             liquidateCollateralFactor: exp(0.9, 18) + 1n,
           }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
@@ -271,7 +374,7 @@ describe('asset info', function () {
         it('gap = DESCALE - 1: maximum same-bin gap — liquidateCF still truncates to the same bin', async () => {
           // 9001*DESCALE - 1 truncates to 9000, same as 9000*DESCALE
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18),
             liquidateCollateralFactor: exp(0.9, 18) + DESCALE - 1n,
           }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
@@ -280,7 +383,7 @@ describe('asset info', function () {
         it('both values are non-zero and inside the same bin', async () => {
           // borrowCF = 9000*DESCALE + 1, liquidateCF = 9001*DESCALE - 1 → both truncate to 9000
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.9, 18) + 1n,
             liquidateCollateralFactor: exp(0.9, 18) + DESCALE - 1n,
           }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');
@@ -289,7 +392,7 @@ describe('asset info', function () {
         it('same-bin collision at a different factor magnitude', async () => {
           // 7000*DESCALE and 7000*DESCALE + 1 both truncate to 7000 → equal after descale
           await expect(assetListFactory.createAssetList([{
-            ...baseAssetConfig,
+            ...collateralAssetConfig,
             borrowCollateralFactor: exp(0.7, 18),
             liquidateCollateralFactor: exp(0.7, 18) + 1n,
           }])).to.be.revertedWithCustomError(assetList, 'BorrowCFTooLarge');

--- a/test/is-borrow-collateralized-test.ts
+++ b/test/is-borrow-collateralized-test.ts
@@ -1,4 +1,4 @@
-import { CometProxyAdmin, Configurator, CometHarnessInterfaceExtendedAssetList as CometWithExtendedAssetList, FaucetToken, NonStandardFaucetFeeToken, PriceFeedWithRevert, PriceFeedWithRevert__factory } from 'build/types';
+import { CometExt, CometProxyAdmin, Configurator, CometHarnessInterfaceExtendedAssetList as CometWithExtendedAssetList, FaucetToken, NonStandardFaucetFeeToken, PriceFeedWithRevert, PriceFeedWithRevert__factory } from 'build/types';
 import { expect, exp, makeProtocol, makeConfigurator, ethers, updateAssetBorrowCollateralFactor, getLiquidity, SnapshotRestorer, takeSnapshot, MAX_ASSETS } from './helpers';
 import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
@@ -150,7 +150,6 @@ describe('isBorrowCollateralized', function () {
    * unpriceable collateral.
    */
   describe('isBorrowCollateralized semantics across borrowCollateralFactor values', function () {
-    // Snapshot
     let snapshot: SnapshotRestorer;
 
     // Configurator and protocol
@@ -159,6 +158,7 @@ describe('isBorrowCollateralized', function () {
     let proxyAdmin: CometProxyAdmin;
     let cometProxyAddress: string;
     let comet: CometWithExtendedAssetList;
+    let priceFeedWithRevert: PriceFeedWithRevert;
 
     // Tokens
     let baseSymbol: string;
@@ -168,6 +168,7 @@ describe('isBorrowCollateralized', function () {
 
     // Users
     let alice: SignerWithAddress;
+    let pauseGuardian: SignerWithAddress;
 
     // Values
     let supplyAmount: bigint;
@@ -198,6 +199,7 @@ describe('isBorrowCollateralized', function () {
       baseToken = protocol.tokens[baseSymbol];
       collateralToken = protocol.tokens['ASSET0'];
       alice = protocol.users[0];
+      pauseGuardian = protocol.pauseGuardian;
 
       // Upgrade proxy to extended asset list implementation to support many assets
       const assetListFactory = protocol.assetListFactory;
@@ -217,6 +219,10 @@ describe('isBorrowCollateralized', function () {
       await CometFactoryWithExtendedAssetList.deployed();
       await configurator.setFactory(cometProxyAddress, CometFactoryWithExtendedAssetList.address);
       await proxyAdmin.deployAndUpgradeTo(configuratorProxyAddress, cometProxyAddress);
+
+      // Deploy a price feed that always reverts on latestRoundData
+      const PriceFeedWithRevertFactory = (await ethers.getContractFactory('PriceFeedWithRevert')) as PriceFeedWithRevert__factory;
+      priceFeedWithRevert = await PriceFeedWithRevertFactory.deploy(100, 8);
 
       snapshot = await takeSnapshot();
 
@@ -345,25 +351,14 @@ describe('isBorrowCollateralized', function () {
         await snapshot.restore();
       });
     }
-
-    /*
-     * Edge cases around price feeds and isBorrowCollateralized.
-     *
-     * These tests simulate a governance action that replaces a collateral asset's price feed
-     * with a feed that always reverts on `latestRoundData` (PriceFeedWithRevert). This mirrors
-     * the "price feed paralysis" scenario exercised in the absorb and quoteCollateral tests,
-     * but focused on `isBorrowCollateralized`:
-     *
-     * 1. With the normal price feed, isBorrowCollateralized should succeed for Alice's position.
-     * 2. After governance updates the asset's price feed to PriceFeedWithRevert, isBorrowCollateralized
-     *    should revert with the `Reverted` custom error, since it calls getPrice(asset.priceFeed)
-     *    while iterating over collateral assets.
-     * 3. When governance restores the original (non-reverting) price feed, isBorrowCollateralized
-     *    should succeed again, showing that the paralysis is solely caused by the reverting feed.
-     */
+    
     describe('edge cases', function () {
+      /*
+       * Tests three resolution paths for price-feed paralysis in isBorrowCollateralized: restoring
+       * the original feed, setting borrowCF to 0, and deactivating the collateral via the pause
+       * guardian. Each path proves that the Reverted error from a broken feed can be unblocked.
+       */
       describe('revert on price feed side', function () {
-        let priceFeedWithRevert: PriceFeedWithRevert;
         let originalPriceFeed: string;
 
         before(async () => {
@@ -381,11 +376,6 @@ describe('isBorrowCollateralized', function () {
 
           // Capture the current (normal) price feed for the collateral token
           originalPriceFeed = (await comet.getAssetInfoByAddress(collateralToken.address)).priceFeed;
-
-          // Deploy a price feed that always reverts on latestRoundData
-          const PriceFeedWithRevertFactory = (await ethers.getContractFactory('PriceFeedWithRevert')) as PriceFeedWithRevert__factory;
-          priceFeedWithRevert = await PriceFeedWithRevertFactory.deploy(100, 8);
-          await priceFeedWithRevert.deployed();
         });
 
         it('sanity check: isBorrowCollateralized works with the normal price feed', async () => {
@@ -418,6 +408,109 @@ describe('isBorrowCollateralized', function () {
 
         it('isBorrowCollateralized works again after restoring the normal price feed', async () => {
           expect(await comet.isBorrowCollateralized(alice.address)).to.be.true;
+        });
+      });
+
+      /*
+       * Demonstrates that setting borrowCollateralFactor to 0 resolves price-feed paralysis:
+       * once governance zeros a reverting asset's borrowCF, isBorrowCollateralized skips that
+       * asset's getPrice() call entirely and returns normally instead of reverting.
+       */
+      describe('zero borrowCF resolves price feed paralysis in isBorrowCollateralized', function () {
+        before(async () => {
+          await snapshot.restore();
+
+          supplyAmount = exp(10, 18);
+          borrowAmount = exp(5, 6);
+          await collateralToken.allocateTo(alice.address, supplyAmount);
+          await collateralToken.connect(alice).approve(cometProxyAddress, supplyAmount);
+          await comet.connect(alice).supply(collateralToken.address, supplyAmount);
+          await baseToken.allocateTo(cometProxyAddress, borrowAmount);
+          await comet.connect(alice).withdraw(baseToken.address, borrowAmount);
+        });
+
+        it('isBorrowCollateralized works with the normal price feed', async () => {
+          expect(await comet.isBorrowCollateralized(alice.address)).to.be.true;
+        });
+
+        it('governance updates collateral price feed to a reverting implementation', async () => {
+          await configurator.updateAssetPriceFeed(cometProxyAddress, collateralToken.address, priceFeedWithRevert.address);
+          await proxyAdmin.deployAndUpgradeTo(configuratorProxyAddress, cometProxyAddress);
+        });
+
+        it('price feed for collateral asset is now the reverting implementation', async () => {
+          expect((await comet.getAssetInfoByAddress(collateralToken.address)).priceFeed).to.equal(priceFeedWithRevert.address);
+        });
+
+        it('isBorrowCollateralized reverts when collateral price feed reverts', async () => {
+          await expect(comet.isBorrowCollateralized(alice.address)).to.be.revertedWithCustomError(priceFeedWithRevert, 'Reverted');
+        });
+
+        it('governance sets borrowCollateralFactor to 0 for the affected asset', async () => {
+          await updateAssetBorrowCollateralFactor(configurator, proxyAdmin, cometProxyAddress, collateralToken.address, 0n);
+        });
+
+        it('borrowCollateralFactor is 0 after upgrade', async () => {
+          expect((await comet.getAssetInfoByAddress(collateralToken.address)).borrowCollateralFactor).to.equal(0);
+        });
+
+        it('isBorrowCollateralized succeeds and position is undercollateralized after borrowCF is set to 0', async () => {
+          expect(await comet.isBorrowCollateralized(alice.address)).to.be.false;
+        });
+      });
+
+      /*
+       * Demonstrates that deactivating a collateral via the pause guardian resolves price-feed
+       * paralysis: the deactivation check in isBorrowCollateralized runs before any getPrice()
+       * call, so the function now reverts with the protocol-controlled TokenIsDeactivated error
+       * instead of the uncontrolled external Reverted error from the broken price feed.
+       */
+      describe('token deactivation resolves price feed paralysis in isBorrowCollateralized', function () {
+        let cometExt: CometExt;
+        let collateralAssetIndex: number;
+
+        before(async () => {
+          await snapshot.restore();
+
+          supplyAmount = exp(10, 18);
+          borrowAmount = exp(5, 6);
+          await collateralToken.allocateTo(alice.address, supplyAmount);
+          await collateralToken.connect(alice).approve(cometProxyAddress, supplyAmount);
+          await comet.connect(alice).supply(collateralToken.address, supplyAmount);
+          await baseToken.allocateTo(cometProxyAddress, borrowAmount);
+          await comet.connect(alice).withdraw(baseToken.address, borrowAmount);
+
+          collateralAssetIndex = (await comet.getAssetInfoByAddress(collateralToken.address)).offset;
+          cometExt = comet.attach(cometProxyAddress) as CometExt;
+        });
+
+        it('isBorrowCollateralized works with the normal price feed', async () => {
+          expect(await comet.isBorrowCollateralized(alice.address)).to.be.true;
+        });
+
+        it('governance updates collateral price feed to a reverting implementation', async () => {
+          await configurator.updateAssetPriceFeed(cometProxyAddress, collateralToken.address, priceFeedWithRevert.address);
+          await proxyAdmin.deployAndUpgradeTo(configuratorProxyAddress, cometProxyAddress);
+        });
+
+        it('price feed for collateral asset is now the reverting implementation', async () => {
+          expect((await comet.getAssetInfoByAddress(collateralToken.address)).priceFeed).to.equal(priceFeedWithRevert.address);
+        });
+
+        it('isBorrowCollateralized reverts when collateral price feed reverts', async () => {
+          await expect(comet.isBorrowCollateralized(alice.address)).to.be.revertedWithCustomError(priceFeedWithRevert, 'Reverted');
+        });
+
+        it('pause guardian deactivates the affected collateral', async () => {
+          await expect(cometExt.connect(pauseGuardian).deactivateCollateral(collateralAssetIndex)).to.not.be.reverted;
+        });
+
+        it('collateral is marked as deactivated', async () => {
+          expect(await comet.isCollateralDeactivated(collateralAssetIndex)).to.be.true;
+        });
+
+        it('isBorrowCollateralized reverts with TokenIsDeactivated instead of Reverted', async () => {
+          await expect(comet.isBorrowCollateralized(alice.address)).to.be.revertedWithCustomError(comet, 'TokenIsDeactivated').withArgs(collateralToken.address);
         });
       });
     });

--- a/test/is-liquidatable-test.ts
+++ b/test/is-liquidatable-test.ts
@@ -181,7 +181,6 @@ describe('isLiquidatable', function () {
    * protocol paralysis while ensuring undercollateralized positions can still be liquidated.
    */
   describe('isLiquidatable semantics across liquidateCollateralFactor values', function () {
-    // Snapshot
     let snapshot: SnapshotRestorer;
 
     // Configurator and protocol
@@ -190,6 +189,7 @@ describe('isLiquidatable', function () {
     let configuratorProxyAddress: string;
     let proxyAdmin: CometProxyAdmin;
     let cometProxyAddress: string;
+    let priceFeedWithRevert: PriceFeedWithRevert;
 
     // Tokens
     let baseSymbol: string;
@@ -254,6 +254,10 @@ describe('isLiquidatable', function () {
       await proxyAdmin.deployAndUpgradeTo(configuratorProxyAddress, cometProxyAddress);
 
       liquidateCF = (await comet.getAssetInfoByAddress(collateralToken.address)).liquidateCollateralFactor.toBigInt();
+
+      // Deploy a price feed that always reverts on latestRoundData
+      const PriceFeedWithRevertFactory = (await ethers.getContractFactory('PriceFeedWithRevert')) as PriceFeedWithRevert__factory;
+      priceFeedWithRevert = await PriceFeedWithRevertFactory.deploy(100, 8);
 
       snapshot = await takeSnapshot();
 
@@ -396,24 +400,13 @@ describe('isLiquidatable', function () {
       });
     }
 
-    /*
-     * Edge cases around price feeds and isLiquidatable.
-     *
-     * These tests simulate a governance action that replaces a collateral asset's price feed
-     * with a feed that always reverts on `latestRoundData` (PriceFeedWithRevert). This mirrors
-     * the "price feed paralysis" scenario exercised in the absorb and quoteCollateral tests,
-     * but focused on `isLiquidatable`:
-     *
-     * 1. With the normal price feed, isLiquidatable should succeed for Alice's position.
-     * 2. After governance updates the asset's price feed to PriceFeedWithRevert, isLiquidatable
-     *    should revert with the `Reverted` custom error, since it calls getPrice(asset.priceFeed)
-     *    while iterating over collateral assets.
-     * 3. When governance restores the original (non-reverting) price feed, isLiquidatable
-     *    should succeed again, showing that the paralysis is solely caused by the reverting feed.
-     */
     describe('edge cases', function () {
+      /*
+       * Tests two resolution paths for price-feed paralysis in isLiquidatable: restoring the
+       * original feed, and setting liquidateCF to 0. Each path proves that the Reverted error
+       * from a broken feed can be unblocked without restoring the feed itself.
+       */
       describe('revert on price feed side', function () {
-        let priceFeedWithRevert: PriceFeedWithRevert;
         let originalPriceFeed: string;
 
         before(async () => {
@@ -434,11 +427,6 @@ describe('isLiquidatable', function () {
 
           // Capture the current (normal) price feed for the collateral token
           originalPriceFeed = (await comet.getAssetInfoByAddress(collateralToken.address)).priceFeed;
-
-          // Deploy a price feed that always reverts on latestRoundData
-          const PriceFeedWithRevertFactory = (await ethers.getContractFactory('PriceFeedWithRevert')) as PriceFeedWithRevert__factory;
-          priceFeedWithRevert = await PriceFeedWithRevertFactory.deploy(100, 8);
-          await priceFeedWithRevert.deployed();
         });
 
         it('sanity check: isLiquidatable works with the normal price feed', async () => {
@@ -469,6 +457,56 @@ describe('isLiquidatable', function () {
 
         it('isLiquidatable works again after restoring the normal price feed', async () => {
           expect(await comet.isLiquidatable(alice.address)).to.be.false;
+        });
+      });
+
+      /*
+       * Demonstrates that setting liquidateCollateralFactor to 0 resolves price-feed paralysis:
+       * once governance zeros a reverting asset's liquidateCF, isLiquidatable skips that asset's
+       * getPrice() call entirely and returns normally instead of reverting.
+       */
+      describe('zero liquidateCF resolves price feed paralysis in isLiquidatable', function () {
+        before(async () => {
+          await snapshot.restore();
+
+          supplyAmount = exp(10, 18);
+          borrowAmount = exp(5, 6);
+          await collateralToken.allocateTo(alice.address, supplyAmount);
+          await collateralToken.connect(alice).approve(cometProxyAddress, supplyAmount);
+          await comet.connect(alice).supply(collateralToken.address, supplyAmount);
+          await baseToken.allocateTo(cometProxyAddress, borrowAmount);
+          await comet.connect(alice).withdraw(baseToken.address, borrowAmount);
+        });
+
+        it('isLiquidatable works with the normal price feed', async () => {
+          expect(await comet.isLiquidatable(alice.address)).to.be.false;
+        });
+
+        it('governance updates collateral price feed to a reverting implementation', async () => {
+          await configurator.updateAssetPriceFeed(cometProxyAddress, collateralToken.address, priceFeedWithRevert.address);
+          await proxyAdmin.deployAndUpgradeTo(configuratorProxyAddress, cometProxyAddress);
+        });
+
+        it('price feed for collateral asset is now the reverting implementation', async () => {
+          expect((await comet.getAssetInfoByAddress(collateralToken.address)).priceFeed).to.equal(priceFeedWithRevert.address);
+        });
+
+        it('isLiquidatable reverts when collateral price feed reverts', async () => {
+          await expect(comet.isLiquidatable(alice.address)).to.be.revertedWithCustomError(priceFeedWithRevert, 'Reverted');
+        });
+
+        it('governance sets liquidateCollateralFactor to 0 for the affected asset', async () => {
+          // set borrowCF to 0 first, as we have check in AssetList BCF < LCF
+          await updateAssetBorrowCollateralFactor(configurator, proxyAdmin, cometProxyAddress, collateralToken.address, 0n);
+          await updateAssetLiquidateCollateralFactor(configurator, proxyAdmin, cometProxyAddress, collateralToken.address, 0n, governor);
+        });
+
+        it('liquidateCollateralFactor is 0 after upgrade', async () => {
+          expect((await comet.getAssetInfoByAddress(collateralToken.address)).liquidateCollateralFactor).to.equal(0);
+        });
+
+        it('isLiquidatable succeeds and position is liquidatable after liquidateCF is set to 0', async () => {
+          expect(await comet.isLiquidatable(alice.address)).to.be.true;
         });
       });
     });


### PR DESCRIPTION
Contracts: 

- fix calling price feed in isLiquidatableInternal()
- optimized comments in LCF = 0 and in BCF = 0 in isBorrowCollateralized
- AssetList optimization in factors validation

Missing tests:

- If price feed is broken and factor is set to zero, getPrice will not be reached and tx is not reverted
- AssetList factors validation

### AssetList factors validation

Happy cases

- borrowCF > 0, liquidateCF > 0 and borrowCF < liquidateCF
- borrowCF = 0, liquidateCF = 0
- borrowCF > liquidateF and borrowCF < liquidateCF
- borrowCF < liquidateCF and liquidateCF > liquidateF
- borrowCF < liquidateCF < liquidateF
- borrowCF = 0 and liquidateCF > 0
- borrowCF = 0, liquidateF = 0, liquidateCF > 0
- liquidateCF < MAX_COLLATERAL_FACTOR
- liquidateCF = MAX_COLLATERAL_FACTOR
- liquidateF < MAX_COLLATERAL_FACTOR
- liquidateF = MAX_COLLATERAL_FACTOR

Revert cases

- borrowCF > 0, liquidateCF = 0
- borrowCF > 0, liquidateCF > 0 and borrowCF > liquidateCF
- borrowCF > 0, liquidateCF > 0 and borrowCF = liquidateCF
- liquidateCF > MAX_COLLATERAL_FACTOR
- liquidateF > MAX_COLLATERAL_FACTOR

After descale:

Happy cases:

- Both borrowCF and liquidateCF are exact multiples of DESCALE - no truncation, clean separation
- Gap = exactly one DESCALE unit - minimum valid gap that lands in different bins
- borrowCF just below a bin boundary, liquidateCF at that boundary - different bins by 1 unit after descale
- borrowCF inside a bin, liquidateCF at the start of the next bin - borrowCF rounds down, liquidateCF doesn't
- borrowCF < DESCALE (descales to 0), liquidateCF >= DESCALE - the != 0 guard short-circuits the check entirely
- borrowCF = 0 (zero, not just sub-DESCALE) with liquidateCF below DESCALE - both descale to 0, check still skipped

Revert when:

- gap = 1 - both values fall in the same bin (minimum collision)
- gap = DESCALE - 1 - maximum within-bin gap, liquidateCF still truncates down to borrowCF's bin
- borrowCF and liquidateCF both non-zero and anywhere inside the same bin - arbitrary positions within the bin
- Same-bin collision at a lower magnitude - verifies the bin arithmetic isn't magnitude-specific

Absorb

We had tested cases: 

- LCF > 0 and LF > 0
- LCF > 0 and LF = 0

Added:

- LCF = 0 and LF > 0
- LCF = 0 and LF = 0