### PR TITLE
poc: liquidation reverts on the debtRemainingValue <= liquidity

### DIFF
--- a/test/helpers/liquidation-module.ts
+++ b/test/helpers/liquidation-module.ts
@@ -17,11 +17,13 @@ type DeployLiquidationModuleOpts = {
   dexAdapter?: string;
   borderHF?: bigint;
   healthPositionHF?: bigint;
+  penaltyBps?: bigint;
 };
 
 const DEFAULT_DEX_ADAPTER = '0x1111111111111111111111111111111111111111';
 const DEFAULT_BORDER_HF = exp(102, 16); // 1.02e18
 const DEFAULT_HEALTH_POSITION_HF = exp(110, 16); // 1.10e18
+const DEFAULT_PENALTY_BPS = 500n; // 5% executor penalty on the DEX route
 
 export async function deployAndUpdateLiquidationModule(
   opts: DeployLiquidationModuleOpts
@@ -38,7 +40,8 @@ export async function deployAndUpdateLiquidationModule(
     opts.pausers,
     opts.dexAdapter ?? DEFAULT_DEX_ADAPTER,
     opts.borderHF ?? DEFAULT_BORDER_HF,
-    opts.healthPositionHF ?? DEFAULT_HEALTH_POSITION_HF
+    opts.healthPositionHF ?? DEFAULT_HEALTH_POSITION_HF,
+    opts.penaltyBps ?? DEFAULT_PENALTY_BPS
   );
 
   await opts.comet.connect(opts.governor).setLiquidationModule(liquidationModule.address);

--- a/test/liquidation-module/poc-dex-route-notliquidatable-realistic.test.ts
+++ b/test/liquidation-module/poc-dex-route-notliquidatable-realistic.test.ts
@@ -1,0 +1,134 @@
+import { ethers, exp, expect, makeProtocol, mulPrice, mulFactor } from '../helpers';
+import { CometHarnessInterfaceExtendedAssetList, LiquidationModule, FaucetToken, SimplePriceFeed } from 'build/types';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+
+/**
+ * PoC for finding C-1 — realistic variant (NO setBasePrincipal / setCollateralBalance).
+ *
+ * The position is built entirely through ordinary user actions:
+ *   - Bob supplies USDC base liquidity.
+ *   - Alice supplies 10 COMP ($1,000 @ $100) and borrows $700 (within the 0.80 borrowCF cap of $800).
+ * A market price move then drops COMP just enough to push Alice's health factor into the
+ * (borderHF 1.02, healthPositionHF 1.10] band that `LiquidationModule.liquidate` routes to the
+ * DEX / partial-liquidation path.
+ *
+ * Result: the keeper liquidation reverts with `NotLiquidatable` (fired by the shared
+ * `_computeSeizurePlan` guard `debtRemainingValue <= liquidity`, i.e. HF >= 1.0), even though
+ * Comet's own `isLiquidatable` reports the account as healthy. The DEX route is unreachable.
+ *
+ * Worked numbers (USD in PRICE_SCALE 1e8, factors in FACTOR_SCALE 1e18), COMP dropped $100 → ~$86.47:
+ *   debt                   = $700                                  → debtValue = 7.000e10
+ *   collateral             = 10 COMP @ ~$86.47                     → fullValue ≈ 8.647e10 ($864.7)
+ *   LCF-weighted liquidity = fullValue * 0.85           ≈ 7.350e10 ($735.0)
+ *   currentHF              = 7.350e10 * 1e18 / 7.000e10 ≈ 1.05e18  (inside the DEX band)
+ *
+ *   routing : 1.02e18 < 1.05e18 <= 1.10e18           ⇒ _dexLiquidate           (enters DEX path)
+ *   guard   : 7.000e10 <= 7.350e10                   ⇒ revert NotLiquidatable   (path can never run)
+ *   isLiquidatable = (-7.000e10 + 7.350e10 < 0)      = FALSE                    (Comet: healthy)
+ */
+describe('PoC C-1 (realistic): DEX/partial liquidation reverts via real supply/borrow', function () {
+  const FACTOR_SCALE = exp(1, 18);
+  const BORDER_HF = exp(102, 16);          // 1.02e18
+  const HEALTH_POSITION_HF = exp(110, 16); // 1.10e18
+  const TARGET_BAND_HF = exp(105, 16);     // aim for mid-band 1.05e18
+
+  let comet: CometHarnessInterfaceExtendedAssetList;
+  let liquidationModule: LiquidationModule;
+  let baseToken: FaucetToken;
+  let COMP: FaucetToken;
+  let compPriceFeed: SimplePriceFeed;
+
+  let executor: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let absorber: SignerWithAddress;
+
+  async function currentHF(account: string): Promise<bigint> {
+    const accountUser = await comet.userBasic(account);
+    const pv = (await comet.presentValue(accountUser.principal)).toBigInt(); // negative for a borrower
+    const basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
+    const baseScale = (await comet.baseScale()).toBigInt();
+    const debtValue = mulPrice(-pv, basePrice, baseScale);
+
+    const info = await comet.getAssetInfoByAddress(COMP.address);
+    const compPrice = (await comet.getPrice(info.priceFeed)).toBigInt();
+    const balance = (await comet.userCollateral(account, COMP.address)).balance.toBigInt();
+    const liquidity = mulFactor(mulPrice(balance, compPrice, info.scale), info.liquidateCollateralFactor);
+
+    return (liquidity * FACTOR_SCALE) / debtValue;
+  }
+
+  before(async () => {
+    const protocol = await makeProtocol({
+      base: 'USDC',
+      baseBorrowMin: 0,
+      assets: {
+        USDC: { decimals: 6, initialPrice: 1 },
+        COMP: { decimals: 18, initialPrice: 100 },
+      },
+    });
+    comet = protocol.comet;
+    liquidationModule = protocol.defaultLiquidationModule;
+    executor = protocol.executor;
+    [alice, bob, absorber] = protocol.users;
+    baseToken = protocol.tokens['USDC'] as FaucetToken;
+    COMP = protocol.tokens['COMP'] as FaucetToken;
+    compPriceFeed = protocol.priceFeeds['COMP'];
+
+    // Bob seeds base liquidity so Alice's borrow can be drawn from the market.
+    const baseLiquidity = exp(5_000, 6);
+    await baseToken.allocateTo(bob.address, baseLiquidity);
+    await baseToken.connect(bob).approve(comet.address, baseLiquidity);
+    await comet.connect(bob).supply(baseToken.address, baseLiquidity);
+
+    // Alice opens a real position: supply 10 COMP ($1,000 @ $100), borrow $700 (cap is $800 @ borrowCF 0.80).
+    const collateralAmount = exp(10, 18);
+    await COMP.allocateTo(alice.address, collateralAmount);
+    await COMP.connect(alice).approve(comet.address, collateralAmount);
+    await comet.connect(alice).supply(COMP.address, collateralAmount);
+    await comet.connect(alice).withdraw(baseToken.address, exp(700, 6));
+  });
+
+  it('sanity: Alice starts well-collateralized and not liquidatable', async () => {
+    expect(await comet.isLiquidatable(alice.address)).to.equal(false);
+    expect(await currentHF(alice.address)).to.be.greaterThan(HEALTH_POSITION_HF); // HF ≈ 1.21 > 1.10
+  });
+
+  it('a market price drop into the (borderHF, healthPositionHF] band makes the keeper liquidation revert NotLiquidatable', async () => {
+    // Solve for the COMP price that lands Alice at ~1.05 HF given her actual on-chain debt.
+    const accountUser = await comet.userBasic(alice.address);
+    const pv = (await comet.presentValue(accountUser.principal)).toBigInt();
+    const basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
+    const baseScale = (await comet.baseScale()).toBigInt();
+    const debtValue = mulPrice(-pv, basePrice, baseScale);
+
+    const info = await comet.getAssetInfoByAddress(COMP.address);
+    const balance = (await comet.userCollateral(alice.address, COMP.address)).balance.toBigInt();
+    const LCF = info.liquidateCollateralFactor.toBigInt();
+    const scale = info.scale.toBigInt();
+
+    // currentHF = mulFactor(mulPrice(balance, P, scale), LCF) * 1e18 / debtValue == TARGET_BAND_HF
+    //   ⇒ P = (TARGET_BAND_HF * debtValue / 1e18) * scale * 1e18 / (balance * LCF)
+    const targetLiquidity = (TARGET_BAND_HF * debtValue) / FACTOR_SCALE;
+    const newPrice = (targetLiquidity * scale * FACTOR_SCALE) / (balance * LCF);
+
+    await compPriceFeed.connect(alice).setRoundData(0, newPrice, 0, 0, 0);
+    await comet.accrueAccount(alice.address);
+
+    // Alice is now squarely inside the DEX/partial band.
+    const hf = await currentHF(alice.address);
+    expect(hf).to.be.greaterThan(BORDER_HF);
+    expect(hf).to.be.lessThanOrEqual(HEALTH_POSITION_HF);
+
+    // Comet still reports her as healthy (HF >= 1.0)...
+    expect(await comet.isLiquidatable(alice.address)).to.equal(false);
+
+    // ...but the keeper DEX liquidation reverts at the shared `_computeSeizurePlan` guard,
+    // before any collateral is seized or swapped.
+    await expect(
+      liquidationModule
+        .connect(executor)
+        ['liquidate(address,address,bytes[])'](absorber.address, alice.address, [])
+    ).to.be.revertedWithCustomError(liquidationModule, 'NotLiquidatable');
+  });
+});

--- a/test/liquidation-module/poc-dex-route-notliquidatable.test.ts
+++ b/test/liquidation-module/poc-dex-route-notliquidatable.test.ts
@@ -1,0 +1,138 @@
+import { ethers, exp, expect, makeProtocol, mulPrice, mulFactor } from '../helpers';
+import { CometHarnessInterfaceExtendedAssetList, LiquidationModule, FaucetToken, SimplePriceFeed } from 'build/types';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+
+/**
+ * PoC for finding C-1 — the keeper/DEX liquidation path is dead code.
+ *
+ * `LiquidationModule.liquidate` routes by health factor:
+ *   - HF  > healthPositionHF (1.10) → revert NotLiquidatable   (healthy)
+ *   - borderHF (1.02) < HF <= 1.10  → _dexLiquidate             (DEX / partial route)
+ *   - HF <= borderHF                → _liquidate                (absorb route)
+ *
+ * Both routed paths call `_computeSeizurePlan`, which re-derives the *identical*
+ * LCF-weighted `liquidity` and `debtRemainingValue` and enforces:
+ *
+ *     if (debtRemainingValue <= liquidity) revert NotLiquidatable();   // i.e. HF >= 1e18
+ *
+ * Since the DEX route is only ever entered for HF > borderHF > 1.0, every DEX
+ * liquidation reverts at this guard before any swap. The partial/early-liquidation
+ * feature can never run; only fully-insolvent accounts (HF < 1.0) are liquidatable,
+ * and only via plain absorb.
+ *
+ * This PoC builds an account at HF = 1.05 (squarely inside the DEX band) and shows
+ * the keeper call reverts NotLiquidatable, while Comet itself reports the account as
+ * NOT liquidatable (isLiquidatable == false) — the contradiction at the heart of C-1.
+ */
+describe('PoC C-1: DEX/partial liquidation reverts for in-band accounts', function () {
+  const FACTOR_SCALE = exp(1, 18);
+  const BORDER_HF = exp(102, 16);          // 1.02e18 (deployAndUpdateLiquidationModule default)
+  const HEALTH_POSITION_HF = exp(110, 16); // 1.10e18 (deployAndUpdateLiquidationModule default)
+
+  let comet: CometHarnessInterfaceExtendedAssetList;
+  let liquidationModule: LiquidationModule;
+  let COMP: FaucetToken;
+
+  let executor: SignerWithAddress;
+  let absorber: SignerWithAddress;
+  let alice: SignerWithAddress;
+
+  async function currentHF(account: string): Promise<bigint> {
+    const accountUser = await comet.userBasic(account);
+    const pv = (await comet.presentValue(accountUser.principal)).toBigInt(); // negative for a borrower
+    const basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
+    const baseScale = (await comet.baseScale()).toBigInt();
+    const debtValue = mulPrice(-pv, basePrice, baseScale);
+
+    const info = await comet.getAssetInfoByAddress(COMP.address);
+    const compPrice = (await comet.getPrice(info.priceFeed)).toBigInt();
+    const balance = (await comet.userCollateral(account, COMP.address)).balance.toBigInt();
+    const liquidity = mulFactor(mulPrice(balance, compPrice, info.scale), info.liquidateCollateralFactor);
+
+    return (liquidity * FACTOR_SCALE) / debtValue;
+  }
+
+  before(async () => {
+    // COMP priced at $1 keeps the HF arithmetic transparent; factors fall back to the
+    // makeProtocol defaults (borrowCF 0.80, liquidateCF 0.85, liquidationFactor 0.90).
+    const protocol = await makeProtocol({
+      base: 'USDC',
+      assets: {
+        USDC: { decimals: 6, initialPrice: 1 },
+        COMP: { decimals: 18, initialPrice: 1 },
+      },
+    });
+    comet = protocol.comet;
+    liquidationModule = protocol.defaultLiquidationModule;
+    executor = protocol.executor;
+    alice = protocol.users[0];
+    absorber = protocol.users[1];
+    COMP = protocol.tokens['COMP'] as FaucetToken;
+  });
+
+  it('sanity: module is configured with the documented in-band thresholds (both > 1.0)', async () => {
+    expect(await liquidationModule.borderHF()).to.equal(BORDER_HF);
+    expect(await liquidationModule.healthPositionHF()).to.equal(HEALTH_POSITION_HF);
+    expect(BORDER_HF).to.be.greaterThan(FACTOR_SCALE); // 1.02 > 1.00
+  });
+
+  /*
+   * Numerical example (all USD values in PRICE_SCALE = 1e8, factors in FACTOR_SCALE = 1e18):
+   *
+   *   Position:        debt   = 85 USDC  @ $1   → debtValue  = 85  * 1e8 = 8.500e9  ($85)
+   *                    collat = 105 COMP @ $1   → fullValue  = 105 * 1e8 = 1.050e10 ($105)
+   *   Factors (COMP):  borrowCF = 0.80,  liquidateCF (LCF) = 0.85,  liquidationFactor = 0.90
+   *
+   *   LCF-weighted liquidity = fullValue * LCF = 1.050e10 * 0.85 = 8.925e9   ($89.25)
+   *   currentHF              = liquidity * 1e18 / debtValue
+   *                         = 8.925e9 * 1e18 / 8.500e9 = 1.05e18            (HF = 1.05)
+   *
+   *   Step 1 — LiquidationModule.liquidate routing:
+   *     borderHF (1.02e18) < currentHF (1.05e18) <= healthPositionHF (1.10e18)
+   *     ⇒ routes to _dexLiquidate.                                          ✓ enters DEX path
+   *
+   *   Step 2 — _computeSeizurePlan guard (same liquidity & debtValue, re-derived):
+   *     if (debtRemainingValue <= liquidity)  →  if (8.500e9 <= 8.925e9)  → TRUE
+   *     ⇒ revert NotLiquidatable().                                        ✗ DEX path can never run
+   *
+   *   Meanwhile isLiquidatable = (debt + liquidity < 0) = (-8.500e9 + 8.925e9 < 0) = FALSE
+   *   ⇒ Comet considers the account healthy. The guard (HF >= 1.0) and the routing band
+   *     (HF up to 1.10) are mutually exclusive, so every in-band account reverts.
+   */
+  it('reverts NotLiquidatable for an account squarely inside the DEX band (HF = 1.05)', async () => {
+    // $85 debt, 105 COMP @ $1 collateral.
+    // HF_LCF = (105 * $1 * 0.85) / $85 = $89.25 / $85 = 1.05  → inside (1.02, 1.10].
+    await comet.setBasePrincipal(alice.address, -85_000_000); // -85 USDC (baseScale 1e6)
+    await comet.setCollateralBalance(alice.address, COMP.address, exp(105, 18));
+
+    // The account sits in the band the DEX/partial route is meant to handle.
+    const hf = await currentHF(alice.address);
+    expect(hf).to.equal(exp(105, 16)); // exactly 1.05e18
+    expect(hf).to.be.greaterThan(BORDER_HF);
+    expect(hf).to.be.lessThanOrEqual(HEALTH_POSITION_HF);
+
+    // Yet Comet's own liquidatability check (debt > LCF-liquidity, i.e. HF < 1.0) says "healthy".
+    expect(await comet.isLiquidatable(alice.address)).to.equal(false);
+
+    // The keeper liquidation (routes to _dexLiquidate → _computeSeizurePlan) reverts at the
+    // `debtRemainingValue <= liquidity` guard, before any collateral is seized or swapped.
+    await expect(
+      liquidationModule
+        .connect(executor)
+        ['liquidate(address,address,bytes[])'](absorber.address, alice.address, [])
+    ).to.be.revertedWithCustomError(liquidationModule, 'NotLiquidatable');
+  });
+
+  it('contrast: the same account is only liquidatable once HF drops below 1.0 (outside the DEX band)', async () => {
+    // Drop collateral to 80 COMP → HF_LCF = (80 * 0.85) / 85 = $68 / $85 ≈ 0.80 < 1.0.
+    await comet.setBasePrincipal(alice.address, -85_000_000);
+    await comet.setCollateralBalance(alice.address, COMP.address, exp(80, 18));
+
+    const hf = await currentHF(alice.address);
+    expect(hf).to.be.lessThan(FACTOR_SCALE); // < 1.0
+
+    // Below 1.0 the account IS liquidatable by Comet's definition — confirming the protocol only
+    // permits liquidation for HF < 1.0, never for the 1.02–1.10 band the DEX feature was built for.
+    expect(await comet.isLiquidatable(alice.address)).to.equal(true);
+  });
+});


### PR DESCRIPTION
# DEX / partial liquidation path always reverts (`NotLiquidatable`) — PoC

## Summary
`LiquidationModule.liquidate` routes accounts with `borderHF < HF <= healthPositionHF` to the DEX / partial-liquidation path. That path calls `_computeSeizurePlan`, which re-derives the **same** LCF-weighted `liquidity` and `debtValue` and enforces:

```solidity
if (debtRemainingValue <= liquidity) revert NotLiquidatable(); // i.e. HF >= 1.0
```

Since the DEX route is only entered for `HF > borderHF > 1.0`, this guard reverts **every** DEX liquidation before any collateral is seized or swapped.

## Impact
With the documented config (`borderHF 1.02`, `healthPositionHF 1.10`, `targetHF 1.05`), the entire DEX / early-liquidation feature is unreachable. Only fully-insolvent accounts (`HF < 1.0`) are liquidatable, and only via plain absorb. No funds are lost or frozen (absorb backstop is intact) → **severity: High**.

## PoC
Two passing tests under `test/liquidation-module/`:
- `poc-dex-route-notliquidatable.test.ts` — minimal/deterministic (harness setters) + contrast test.
- `poc-dex-route-notliquidatable-realistic.test.ts` — end-to-end via real `supply` / `borrow` + market price drop.

Both place an account at **HF ≈ 1.05** (inside the DEX band) and show:
1. routing enters `_dexLiquidate`,
2. `comet.isLiquidatable() == false` (Comet considers it healthy),
3. `liquidate(absorber, account, [])` reverts `NotLiquidatable`.

```bash
npx hardhat test test/liquidation-module/poc-dex-route-notliquidatable.test.ts \
                 test/liquidation-module/poc-dex-route-notliquidatable-realistic.test.ts
```